### PR TITLE
add parameter -T makting the pyodbc trust the server certificate (MSSQL)

### DIFF
--- a/sqpy/cli.py
+++ b/sqpy/cli.py
@@ -50,6 +50,13 @@ def setup_args():
     )
 
     parser.add_argument(
+        '-T',
+        dest='trust_server_certificate',
+        help="Trust the server certificate",       
+        action='store_true'
+    )
+
+    parser.add_argument(
         '-C',
         dest='sql',
         help="SQL command to execute (can also be passed in via STDIN)",
@@ -173,6 +180,9 @@ def main():
 
     if args.password:
         dsn += [f'PWD={args.password}']
+
+    if args.trust_server_certificate:
+        dsn += [f'TrustServerCertificate=YES']
 
     conn = pyodbc.connect(';'.join(dsn))
     cur = conn.cursor()


### PR DESCRIPTION
Adds an additional parameter to trust the server certificate of a MSSQL host. The new MSSQL driver 18 uses by default a SSL connection and the default mssql docker image e.g. the [microsoft-mssql-server](https://hub.docker.com/_/microsoft-mssql-server) which I use for testing uses a self-signed SSL certificate.

*Note:* Paramter `-T` is not defined in `sqsh` so this should cause any troubles.